### PR TITLE
[BUGFIX beta] Don't use old method names with the new injection system.

### DIFF
--- a/packages/ember-data/lib/initializers/store-injections.js
+++ b/packages/ember-data/lib/initializers/store-injections.js
@@ -6,7 +6,10 @@
   @param {Ember.Registry} registry
 */
 export default function initializeStoreInjections(registry) {
-  registry.injection('controller', 'store', 'service:store');
-  registry.injection('route', 'store', 'service:store');
-  registry.injection('data-adapter', 'store', 'service:store');
+  // registry.injection for Ember < 2.1.0
+  // application.inject for Ember 2.1.0+
+  var inject = registry.injection || registry.inject;
+  inject.call(registry, 'controller', 'store', 'service:store');
+  inject.call(registry, 'route', 'store', 'service:store');
+  inject.call(registry, 'data-adapter', 'store', 'service:store');
 }

--- a/packages/ember-data/lib/initializers/store.js
+++ b/packages/ember-data/lib/initializers/store.js
@@ -20,8 +20,11 @@ function has(applicationOrRegistry, fullName) {
   @param {Ember.Registry} registry
 */
 export default function initializeStore(registry) {
-  registry.optionsForType('serializer', { singleton: false });
-  registry.optionsForType('adapter', { singleton: false });
+  // registry.optionsForType for Ember < 2.1.0
+  // application.registerOptionsForType for Ember 2.1.0+
+  var registerOptionsForType = registry.optionsForType || registry.registerOptionsForType;
+  registerOptionsForType.call(registry, 'serializer', { singleton: false });
+  registerOptionsForType.call(registry, 'adapter', { singleton: false });
 
   registry.register('serializer:-default', JSONSerializer);
   registry.register('serializer:-rest', RESTSerializer);
@@ -31,7 +34,7 @@ export default function initializeStore(registry) {
   registry.register('serializer:-json-api', JSONAPISerializer);
 
 
-  if (has(registry, 'service:store')) {
+  if (!has(registry, 'service:store')) {
     registry.register('service:store', Store);
   }
 }

--- a/packages/ember-data/tests/integration/setup-container-test.js
+++ b/packages/ember-data/tests/integration/setup-container-test.js
@@ -1,11 +1,9 @@
 var run = Ember.run;
-var Container = Ember.Container;
-var Registry = Ember.Registry;
 var Store = DS.Store;
 var EmberObject = Ember.Object;
 var setupContainer = DS._setupContainer;
 
-var container, registry;
+var container, registry, application;
 
 /*
   These tests ensure that Ember Data works with Ember.js' container
@@ -14,18 +12,28 @@ var container, registry;
 
 module("integration/setup-container - Setting up a container", {
   setup: function() {
-    if (Registry) {
-      registry = new Registry();
-      container = registry.container();
+    run(function() {
+      application = Ember.Application.create();
+    });
+
+    container = application.__container__;
+    registry = application.__registry__;
+
+    var setupContainerArgument;
+    if (registry) {
+      setupContainerArgument = application;
     } else {
-      container = new Container();
-      registry = container;
+      // In Ember < 2.1.0 application.__registry__ is undefined so we
+      // pass in the registry to mimic the setup behavior.
+      registry = setupContainerArgument = application.registry;
     }
-    setupContainer(registry);
+    setupContainer(setupContainerArgument);
   },
 
   teardown: function() {
-    run(container, container.destroy);
+    run(function() {
+      application.destroy();
+    });
   }
 });
 


### PR DESCRIPTION
In the new initializer system intection has been renamed to inject and
optionsForType has been renamed to registerOptionsForType.
