### PR TITLE
Explicitly name the namespace

### DIFF
--- a/addon/-private/core.js
+++ b/addon/-private/core.js
@@ -17,8 +17,9 @@ import VERSION from 'ember-data/version';
   @type String
   @static
 */
-var DS = Ember.Namespace.create({
-  VERSION: VERSION
+const DS = Ember.Namespace.create({
+  VERSION: VERSION,
+  name: "DS"
 });
 
 if (Ember.libraries) {


### PR DESCRIPTION
Since the DS namespace is not added to Ember.lookup anymore, the name
for the namespace needs to be defined explicitly.
